### PR TITLE
update URLS since main implementation and docs moved to postcode.eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Postcode.nl API REST Client
 
-A ASP.Net 4.5.1+ class, which offers methods to directly talk with the [Postcode.nl API](https://api.postcode.nl/documentation) through the REST endpoint offered.
-You will need to create an account with the [Postcode.nl API](https://api.postcode.nl) service.
+A ASP.Net 4.5.1+ class, which offers methods to directly talk with the [Postcode.nl API](https://developer.postcode.eu/documentation) through the REST endpoint offered.
+You will need to create an account with the [Postcode.nl API](https://www.postcode.nl/services/adresdata/api) service.
 
 
 ## License
@@ -21,8 +21,8 @@ Or download the source from my GitHub page: https://github.com/janssenr/Postcode
 Include the class in your ASP.Net project, instantiate the ASP.Net class with your authentication details and call the 'LookupAddress' method.
 You can handle errors by catching the defined Exception classes.
 
-* See our [Address API description](https://services.postcode.nl/adresdata/api) for more information
-* See our [Address API method documentation](https://api.postcode.nl/documentation/address-api) for the possible fields
+* See our [Address API description](https://www.postcode.nl/services/adresdata/api) for more information
+* See our [Address API method documentation](https://developer.postcode.eu/documentation/nl/overview) for the possible fields
 
 ```
 var api = new PostcodeNlApiRestClient(apiKey: "<your key>", apiSecret: "<your secret>");

--- a/src/PostcodeNlApi.Example/Default.aspx
+++ b/src/PostcodeNlApi.Example/Default.aspx
@@ -17,7 +17,7 @@
     <form id="form1" runat="server">
         <h1>Postcode.nl API REST client example</h1>
         <ul>
-            <li><a href="https://api.postcode.nl/documentation">Postcode.nl API documentation</a></li>
+            <li><a href="https://developer.postcode.eu/documentation">Postcode.nl API documentation</a></li>
         </ul>
         <fieldset>
             <legend>Authentication</legend>

--- a/src/PostcodeNlApi.Example/Default.aspx.cs
+++ b/src/PostcodeNlApi.Example/Default.aspx.cs
@@ -12,7 +12,6 @@ public partial class _Default : System.Web.UI.Page
         pnlRawRequestResponse.Visible = false;
         if (!IsPostBack)
         {
-            //txtApiUrl.Text = "https://api.postcode.nl/rest";
             txtApiUrl.Text = "https://api.postcode.eu/nl/v1";
             txtKey.Text = WebConfigurationManager.AppSettings["appKey"];
             txtSecret.Text = WebConfigurationManager.AppSettings["appSecret"];

--- a/src/PostcodeNlApi/PostcodeNlApiRestClient.cs
+++ b/src/PostcodeNlApi/PostcodeNlApiRestClient.cs
@@ -69,7 +69,7 @@ namespace PostcodeNlApi
         /// <summary>
         /// Default URL where the REST web service is located
         /// </summary>
-        private readonly string _restApiUrl = "https://api.postcode.nl/rest";
+        private readonly string _restApiUrl = "https://api.postcode.eu/nl/v1";
         /// <summary>
         /// Internal storage of the application key of the authentication.
         /// </summary>
@@ -106,7 +106,7 @@ namespace PostcodeNlApi
                 _restApiUrl = restApiUrl;
 
             if (string.IsNullOrEmpty(_appKey) || string.IsNullOrEmpty(_appSecret))
-                throw new PostcodeNlApiRestClientException("No application key / secret configured, you can obtain these at https://api.postcode.nl.");
+                throw new PostcodeNlApiRestClientException("No application key / secret configured, you can obtain these at https://account.postcode.eu");
         }
 
         /// <summary>


### PR DESCRIPTION
This has no functional impact - the new _restApiUrl acts the same as the old one, but that has been deprecated for a few years so needs to be updated